### PR TITLE
[3153] Align footer menu to the right side

### DIFF
--- a/assets/styles/layouts/Footer.scss
+++ b/assets/styles/layouts/Footer.scss
@@ -137,7 +137,7 @@
 
 	&__navigation {
 		display: grid;
-		grid-template-columns: repeat(auto-fill, 150px);
+		grid-template-columns: repeat(auto-fit, minmax(9.375em, 1fr));
 		justify-content: space-between;
 		color: $black;
 		margin-top: 2.5em;
@@ -145,7 +145,13 @@
 
 
 		@media (min-width: $breakpoint-tablet) {
-			grid-template-columns: repeat(4, 150px);
+			grid-template-columns: repeat(auto-fit, minmax(9.375em, 1fr));
+			grid-auto-flow: column;
+			width: 100%;
+
+			li {
+				min-width: 150px;
+			}
 		}
 
 		a {


### PR DESCRIPTION
**Changes proposed in this Pull Request**
I rewrote the grid for the footer menus, which aligns the menus to the right

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#3153
