### PR TITLE
[3154] Add gap between sections in the Pricing

### DIFF
--- a/assets/styles/components/_PricingPrograms.scss
+++ b/assets/styles/components/_PricingPrograms.scss
@@ -6,6 +6,10 @@ no-descending-specificity, scss/no-global-function-names */
 
 .Pricing {
 
+	&:has(+ div) {
+		margin-bottom: 4em;
+	}
+
 	&__programs {
 		color: $level-2;
 		gap: 2em;


### PR DESCRIPTION
**Changes proposed in this Pull Request**
I added styles for the support if pricing has next element give to him margin bottom

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#3154