### PR TITLE
[3192] Rewrite tools to ai tools and move single page img to content

### DIFF
--- a/assets/styles/components/compactHeader.scss
+++ b/assets/styles/components/compactHeader.scss
@@ -71,6 +71,8 @@ body.compact-header--active {
 
 			&__right {
 
+				display: none;
+
 				picture {
 					height: 100%;
 					display: flex;

--- a/assets/styles/layouts/Post.scss
+++ b/assets/styles/layouts/Post.scss
@@ -50,7 +50,6 @@ no-descending-specificity, scss/no-global-function-names */
 			}
 
 
-
 			.wp-block-embed {
 				margin: 0;
 				padding: 0;

--- a/assets/styles/layouts/Post.scss
+++ b/assets/styles/layouts/Post.scss
@@ -36,6 +36,21 @@ no-descending-specificity, scss/no-global-function-names */
 			display: flex;
 			flex-direction: column;
 
+			&__hero {
+
+				img {
+					opacity: 1;
+					object-fit: cover;
+					width: 100%;
+					max-height: 400px;
+					min-height: 400px;
+					border-radius: 10px;
+					margin-bottom: 4em;
+				}
+			}
+
+
+
 			.wp-block-embed {
 				margin: 0;
 				padding: 0;

--- a/lib/custom-blocks/compact-header.php
+++ b/lib/custom-blocks/compact-header.php
@@ -434,6 +434,7 @@ set_custom_source( 'common/splide', 'css' );
 					</div>
 				<?php } ?>
 			</div>
+			<?php if ( true === $is_infinity ) { ?>
 			<div class="compact-header__right urlslab-skip-lazy">
 				<?php if ( ! empty( $args['image'] ) ) { ?>
 					<?php
@@ -450,6 +451,7 @@ set_custom_source( 'common/splide', 'css' );
 					<?php } ?>
 				<?php } ?>
 			</div>
+			<?php } ?>
 		</div>
 	</div>
 <?php } ?>

--- a/lib/functions/redirects.php
+++ b/lib/functions/redirects.php
@@ -43,3 +43,14 @@ function glossary_category_redirect() {
 	}
 }
 add_action( 'template_redirect', 'glossary_category_redirect' );
+
+/**
+ * Redirect Features Categories
+ */
+function ai_tools_category_redirect() {
+	if ( is_tax( 'tools-categories' ) ) {
+		wp_safe_redirect( '/ai-tools/', 301 );
+		exit;
+	}
+}
+add_action( 'template_redirect', 'ai_tools_category_redirect' );

--- a/lib/post-types.php
+++ b/lib/post-types.php
@@ -5,4 +5,4 @@
 	require_once get_template_directory() . '/lib/post-types/pricing-tables.php';
 	require_once get_template_directory() . '/lib/post-types/checklists.php';
 	require_once get_template_directory() . '/lib/post-types/flow-templates.php';
-	require_once get_template_directory() . '/lib/post-types/tools.php';
+	require_once get_template_directory() . '/lib/post-types/ai-tools.php';

--- a/lib/post-types/ai-tools.php
+++ b/lib/post-types/ai-tools.php
@@ -4,19 +4,19 @@ add_action(
 	'init',
 	function () {
 		$labels  = array(
-			'name'           => _x( 'Tools', 'Post Type General Name', 'flowhunt' ),
-			'singular_name'  => _x( 'Tool', 'Post Type Singular Name', 'flowhunt' ),
-			'menu_name'      => __( 'Tools', 'flowhunt' ),
-			'name_admin_bar' => __( 'Tools', 'flowhunt' ),
+			'name'           => _x( 'AI Tools', 'Post Type General Name', 'flowhunt' ),
+			'singular_name'  => _x( 'AI Tool', 'Post Type Singular Name', 'flowhunt' ),
+			'menu_name'      => __( 'AI Tools', 'flowhunt' ),
+			'name_admin_bar' => __( 'AI Tools', 'flowhunt' ),
 		);
 		$rewrite = array(
-			'slug'       => 'tools',
+			'slug'       => 'ai-tools',
 			'with_front' => true,
 			'pages'      => true,
 			'feeds'      => false,
 		);
 		$args    = array(
-			'label'               => __( 'Tools', 'flowhunt' ),
+			'label'               => __( 'AI Tools', 'flowhunt' ),
 			'labels'              => $labels,
 			'supports'            => array( 'title', 'editor', 'excerpt', 'thumbnail', 'revisions', 'author' ),
 			'hierarchical'        => false,
@@ -35,8 +35,8 @@ add_action(
 			'capability_type'     => 'post',
 			'show_in_rest'        => true,
 			'show_in_graphql'     => true,
-			'graphql_single_name' => 'tool',
-			'graphql_plural_name' => 'tools',
+			'graphql_single_name' => 'ai-tool',
+			'graphql_plural_name' => 'ai-tools',
 		);
 		register_post_type( 'tools', $args );
 	},

--- a/templates/content-archive-tools.php
+++ b/templates/content-archive-tools.php
@@ -6,7 +6,7 @@ if ( is_tax( 'tools-categories' ) ) :
 	$page_header_title       = single_cat_title();
 	$page_header_description = the_archive_description();
 else :
-	$page_header_title       = __( 'Tools', 'flowhunt' );
+	$page_header_title       = __( 'AI Tools', 'flowhunt' );
 	$page_header_description = __( 'Explore the features and components for building AI tools and chatbots. Designed with modularity and flexibility at heart, FlowHunt is ready to support all your automation needs.', 'flowhunt' );
 endif;
 $filter_items_categories = array(
@@ -32,6 +32,7 @@ $filter_items     = array(
 );
 $page_header_args = array(
 	'type'   => 'lvl-1',
+	'is_infinity'   => true,  // set true if header image is infinity to right
 	'image'  => array(
 		'src' => get_template_directory_uri() . '/assets/images/compact-header-features-img.png?ver=' . THEME_VERSION,
 		'alt' => $page_header_title,

--- a/templates/content-single-glossary.php
+++ b/templates/content-single-glossary.php
@@ -34,6 +34,22 @@ $related_args = array(
 		<div class="Post__content">
 
 			<div class="Content" itemprop="articleBody">
+
+				<?php if ( ! empty( $page_header_args['image']['url'] ) ) { ?>
+					<div class="Content__hero">
+						<?php
+						$image = $page_header_args['image'];
+						?>
+						<?php if ( isset( $image['src'] ) ) { ?>
+							<img
+								src="<?= esc_url( $image['src'] ); ?>"
+								alt="<?= esc_attr( $image['alt'] ); ?>"
+								class="Content__hero__img"
+							>
+						<?php } ?>
+					</div>
+				<?php } ?>
+
 				<?php the_content(); ?>
 
 				<?php get_template_part( 'lib/components/related-articles', null, $related_args ); ?>

--- a/templates/content-single-tools.php
+++ b/templates/content-single-tools.php
@@ -14,7 +14,7 @@ if ( has_post_thumbnail() ) {
 }
 $page_header_args = array(
 	'image' => array(
-		'src' => get_template_directory_uri() . '/assets/images/compact-header-features-img.png?ver=' . THEME_VERSION,
+		'src' => get_the_post_thumbnail_url( $post, 'person_thumbnail' ),
 		'alt' => get_the_title(),
 	),
 	'logo'  => ! get_post_meta( get_the_ID(), 'main', true ) ? $page_header_logo : null,
@@ -58,6 +58,23 @@ $related_args = array(
 
 		<div class="Post__content">
 			<div class="Content" itemprop="articleBody">
+
+				<?php if ( ! empty( $page_header_args['image']['src'] ) ) { ?>
+					<div class="Content__hero">
+						<?php
+						$image = $page_header_args['image'];
+						?>
+						<?php if ( isset( $image['src'] ) ) { ?>
+							<img
+								src="<?= esc_url( $image['src'] ); ?>"
+								alt="<?= esc_attr( $image['alt'] ); ?>"
+								class="Content__hero__img"
+							>
+						<?php } ?>
+					</div>
+				<?php } ?>
+
+
 				<?php the_content(); ?>
 
 				<?php get_template_part( 'lib/components/related-articles', null, $related_args ); ?>

--- a/templates/content-single.php
+++ b/templates/content-single.php
@@ -36,6 +36,21 @@ $related_args = array(
 	<div class="wrapper Post__container">
 		<div class="BlogPost__content Post__content">
 			<div class="Content" itemprop="articleBody">
+				<?php if ( ! empty( $page_header_args['image']['url'] ) ) { ?>
+					<div class="Content__hero">
+						<?php
+						$image = $page_header_args['image'];
+						?>
+						<?php if ( isset( $image['src'] ) ) { ?>
+								<img
+									src="<?= esc_url( $image['src'] ); ?>"
+									alt="<?= esc_attr( $image['alt'] ); ?>"
+									class="Content__hero__img"
+								>
+						<?php } ?>
+					</div>
+				<?php } ?>
+
 				<?php the_content(); ?>
 
 				<div class="BlogPost__author-box" itemprop="author" itemscope itemtype="http://schema.org/Person">


### PR DESCRIPTION
**Changes proposed in this Pull Request**
I rewrite postype tools as ai tools.
I've moved the image on individual pages from the header to the content because the header is only created for specific images, not images that content creators have added to posts.

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#3192
Close QualityUnit/web-issues#3169
