### PR TITLE
[3264] fix: spacing between glossary elements

### DIFF
--- a/assets/styles/components/Index.scss
+++ b/assets/styles/components/Index.scss
@@ -7,7 +7,7 @@
 
 	.wrapper {
 		padding: 0.5em;
-		margin-bottom: 0;
+		margin-bottom: 0 !important;
 	}
 
 	&__top {
@@ -63,6 +63,7 @@
 				li {
 					display: inline-block;
 					padding: 0.35em 0;
+					margin-left: 1em;
 
 					a {
 
@@ -85,6 +86,7 @@
 
 					li {
 						width: 33%;
+						margin-left: auto;
 					}
 				}
 			}


### PR DESCRIPTION
**Changes proposed in this Pull Request**
spacing between glossary elements on mobile

Close QualityUnit/web-issues#3264