### PR TITLE
[3295] fix: added styles in post-types pages

### DIFF
--- a/assets/styles/common/_mixins.scss
+++ b/assets/styles/common/_mixins.scss
@@ -25,6 +25,20 @@
 		margin-bottom: 0;
 	}
 
+	@media (min-width: $breakpoint-desktop) {
+		&.mb-10 {
+			margin-bottom: 10em !important;
+
+			&.mb-0 {
+				margin-bottom: 0 !important;
+			}
+
+			.e-con-inner {
+				padding-bottom: 0;
+			}
+		}
+	}
+
 	&.gray-bg {
 		background-color: $gray-50;
 		padding-top: $block-space;
@@ -286,7 +300,7 @@
 	scrollbar-color: $color $white;
 	scroll-behavior: smooth;
 	transition: all .25s;
-	
+
 	&::-webkit-scrollbar-track {
 		background-color: transparent;
 	}

--- a/assets/styles/layouts/_ArchiveColumns.scss
+++ b/assets/styles/layouts/_ArchiveColumns.scss
@@ -65,7 +65,8 @@
 
 	@media (min-width: $breakpoint-tablet-landscape) {
 		grid-template-columns: repeat(3, 1fr);
-		grid-row-gap: 4em;
+		grid-row-gap: 3.125em;
+		margin-bottom: 10em;
 
 		.full {
 			grid-column: 1/4;

--- a/assets/styles/layouts/_ArchiveColumns.scss
+++ b/assets/styles/layouts/_ArchiveColumns.scss
@@ -66,7 +66,6 @@
 	@media (min-width: $breakpoint-tablet-landscape) {
 		grid-template-columns: repeat(3, 1fr);
 		grid-row-gap: 3.125em;
-		margin-bottom: 10em;
 
 		.full {
 			grid-column: 1/4;

--- a/templates/content-archive-features.php
+++ b/templates/content-archive-features.php
@@ -51,7 +51,7 @@ $page_header_args = array(
 <div class="Posts Features" itemScope itemType="http://schema.org/Collection">
 	<?php get_template_part( 'lib/custom-blocks/compact-header', null, $page_header_args ); ?>
 
-	<div class="wrapper-md">
+	<div class="wrapper-md mb-10">
 		<ul class="Posts__items Archive__columns list">
 			<?php
 			while ( have_posts() ) :

--- a/templates/content-archive-flow-templates.php
+++ b/templates/content-archive-flow-templates.php
@@ -50,7 +50,7 @@ $page_header_args = array(
 <div class="Posts flow-templates" itemScope itemType="http://schema.org/Collection">
 	<?php get_template_part( 'lib/custom-blocks/compact-header', null, $page_header_args ); ?>
 
-	<div class="wrapper-md">
+	<div class="wrapper-md mb-10">
 		<ul class="Posts__items Archive__columns list">
 			<?php
 			while ( have_posts() ) :

--- a/templates/content-archive-glossary.php
+++ b/templates/content-archive-glossary.php
@@ -46,7 +46,7 @@ $page_header_args = array(
 <div id="archive" class="Archive" itemscope itemtype="https://schema.org/DefinedTermSet">
 	<?php get_template_part( 'lib/custom-blocks/compact-header', null, $page_header_args ); ?>
 
-	<div class="wrapper-md Index__list">
+	<div class="wrapper-md Index__list mb-10">
 		<?php
 		foreach ( $index as $index_item ) {
 			?>

--- a/templates/content-archive-tools.php
+++ b/templates/content-archive-tools.php
@@ -50,7 +50,7 @@ $page_header_args = array(
 <div class="Posts Tools" itemScope itemType="http://schema.org/Collection">
 	<?php get_template_part( 'lib/custom-blocks/compact-header', null, $page_header_args ); ?>
 
-	<div class="wrapper-md">
+	<div class="wrapper-md mb-10">
 		<ul class="Posts__items Archive__columns list">
 			<?php
 			while ( have_posts() ) :

--- a/templates/content-archive.php
+++ b/templates/content-archive.php
@@ -41,7 +41,7 @@ endif;
 <div id="blog" class="Blog pos-relative" itemscope itemtype="http://schema.org/Blog">
 	<?php get_template_part( 'lib/custom-blocks/compact-header', null, $page_header_args ); ?>
 
-	<div class="Blog__container wrapper-md">
+	<div class="Blog__container wrapper-md mb-10">
 		<div class="blog__top__post">
 			<?php
 			if ( ! is_author() ) {
@@ -67,7 +67,7 @@ endif;
 						<a href="<?php the_permalink(); ?>" title="<?php the_title(); ?>" class="blog__top__post__inn slide__inn" itemprop="url">
 							<div class="blog__top__post__inn--main">
 								<div class="blog__top__post__image">
-									
+
 									<meta itemprop="image" content="<?= esc_url( get_the_post_thumbnail_url( '' ) ); ?>"></meta>
 									<img data-src="<?= esc_url( get_the_post_thumbnail_url( '', 'box_archive_thumbnail' ) ); ?>" alt="<?= esc_attr( get_the_title() ); ?>" />
 								</div>

--- a/templates/content-single-features.php
+++ b/templates/content-single-features.php
@@ -59,7 +59,7 @@ $related_args = array(
 	get_template_part( 'lib/custom-blocks/compact-header', null, $page_header_args );
 	?>
 
-	<div class="Post__container">
+	<div class="Post__container mb-10">
 
 		<div class="Post__content">
 			<div class="Content" itemprop="articleBody">

--- a/templates/content-single-flow-templates.php
+++ b/templates/content-single-flow-templates.php
@@ -60,7 +60,7 @@ $related_args = array(
 	print_r( get_post_meta( get_the_ID(), 'chatbot', true ) );
 	?>
 
-	<div class="wrapper Post__container">
+	<div class="wrapper Post__container mb-10">
 		<div class="Post__content">
 			<div class="Content" itemprop="articleBody">
 				<?php the_content(); ?>

--- a/templates/content-single-glossary.php
+++ b/templates/content-single-glossary.php
@@ -33,7 +33,7 @@ $related_args = array(
 	<span itemprop="publisher" itemscope itemtype="http://schema.org/Organization"><meta itemprop="name" content="URLsLab"></span>
 	<?php get_template_part( 'lib/custom-blocks/compact-header', null, $page_header_args ); ?>
 
-	<div class="wrapper Post__container">
+	<div class="wrapper Post__container mb-10">
 
 		<div class="Post__content">
 

--- a/templates/content-single-tools.php
+++ b/templates/content-single-tools.php
@@ -59,7 +59,7 @@ $related_args = array(
 	get_template_part( 'lib/custom-blocks/compact-header', null, $page_header_args );
 	?>
 
-<div class="Post__container">
+<div class="Post__container mb-10">
 		<div class="Post__content">
 			<div class="Content" itemprop="articleBody">
 
@@ -82,7 +82,7 @@ $related_args = array(
 				<?php the_content(); ?>
 
 				<?php echo do_shortcode( '[urlslab-faq]' ); ?>
-				
+
 				<?php urlslab_display_related_resources(); ?>
 			</div>
 		</div>

--- a/templates/content-single.php
+++ b/templates/content-single.php
@@ -34,7 +34,7 @@ $related_args = array(
 	<span itemprop="publisher" itemscope itemtype="http://schema.org/Organization"><meta itemprop="name" content="LiveAgent"></span>
 	<?php get_template_part( 'lib/custom-blocks/compact-header', null, $page_header_args ); ?>
 
-	<div class="Post__container">
+	<div class="Post__container mb-10">
 		<div class="BlogPost__content Post__content">
 			<div class="Content" itemprop="articleBody">
 				<?php if ( ! empty( $page_header_args['image']['url'] ) ) { ?>
@@ -67,7 +67,7 @@ $related_args = array(
 				</div>
 
 				<?php echo do_shortcode( '[urlslab-faq]' ); ?>
-				
+
 				<?php urlslab_display_related_resources(); ?>
 			</div>
 		</div>


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Added margins for all pages on flowhunt
Changed on admin panel front-page, pricing and AI chatbot pages 
(added mb-10, mb-0 classes in last container)

**Testing instructions**
- go to all pages of flowhunt and check margin between footer and content area (need 160px)
- check margin between posts items (need 50px) on pages like this - https://www.flowhunt.io/features/

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#3295
