### PR TITLE
[3236] - fix: removed block script for lazy-load where we have sidebar-toc

### DIFF
--- a/assets/scripts/custom/sidebar_toc.js
+++ b/assets/scripts/custom/sidebar_toc.js
@@ -37,40 +37,9 @@ function tocRemoveActive() {
 	} );
 }
 
-function loadImg( element ) {
-	if ( element.tagName === 'IMG' && element.parentElement.tagName === 'PICTURE' && ! element.hasAttribute( 'laprocessing' ) ) {
-		element.setAttribute( 'laprocessing', 'y' );
-		element.parentElement.childNodes.forEach( ( childNode ) => {
-			loadImg( childNode );
-		} );
-		element.removeAttribute( 'laprocessing' );
-	}
-
-	if ( element.hasAttribute( 'data-srcset' ) ) {
-		element.setAttribute( 'srcset', element.getAttribute( 'data-srcset' ).replace( /&/g, '&amp;' ).replace( /</g, '&lt;' ).replace( />/g, '&gt;' ) );
-		element.removeAttribute( 'data-srcset' );
-	}
-
-	if ( element.hasAttribute( 'data-src' ) ) {
-		element.setAttribute( 'src', element.getAttribute( 'data-src' ).replace( /&/g, '&amp;' ).replace( /</g, '&lt;' ).replace( />/g, '&gt;' ) );
-		element.removeAttribute( 'data-src' );
-	}
-	element.style.opacity = '1';
-}
-
 function activateSidebars() {
 	let isScrolling;
 	if ( sidebarTOC !== null ) {
-		window.addEventListener( 'load', () => {
-			if ( queryAll( '[data-src]:not(script)' ) !== null ) {
-				const unloaded = document.querySelectorAll( '[data-src]:not(script)' );
-				unloaded.forEach( ( elem ) => {
-					const el = elem;
-					loadImg( el );
-				} );
-			}
-		} );
-
 		tocItems.forEach( ( element, index ) => {
 			const el = element;
 			el.dataset.number = index;


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Removed block script for lazy-load where we have sidebar-toc
It's script duplicated functionality show media, hovewer after load page,
not scroll

**Testing instructions**
- Go to page where we have sidebar-toc, e.g. /features/flow-editor/ and
check images and videos have lazy-load

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#3236
