### PR TITLE
[3381] - fix: fixed black line on video on "The future of AI is modular" 

### DIFF
--- a/assets/styles/components/_FlowModular.scss
+++ b/assets/styles/components/_FlowModular.scss
@@ -182,5 +182,17 @@
 			bottom: -6em;
 		}
 	}
-}
 
+	&__linesAnim {
+
+		&.elementor-widget-video {
+
+			.elementor-wrapper {
+
+				video {
+					background-color: transparent;
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Fixed black line on video on "The future of AI is modular" of homepage

**Testing instructions**
- Go to homepage and check visual view video  on 
"The future of AI is modular" of homepage

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#3381
