### PR TITLE
[3398] - fix: added word break in codeBlock

### DIFF
--- a/assets/styles/components/_CodeBlock.scss
+++ b/assets/styles/components/_CodeBlock.scss
@@ -34,6 +34,7 @@
 	}
 
 	pre.wp-block-code {
+		overflow: hidden;
 		white-space: pre-wrap;
 		word-wrap: break-word;
 		overflow-wrap: break-word;
@@ -50,6 +51,10 @@
 		font-family: $font-primary;
 		padding: 4.125em 1.875rem 1.25rem !important;
 		color: $gray-900 !important;
+		overflow: hidden;
+		white-space: pre-wrap;
+		word-break: break-word;
+		overflow-wrap: break-word;
 
 		&::before {
 			position: absolute;


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Added word break in codeBlock

**Testing instructions**
- Go to articles with code block, e.g. blog/ai-meal-prep-planner/
and check this block

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues#[ISSUE_NUMBER]
